### PR TITLE
Store token metadata

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -30,7 +30,6 @@ impl Iterator for LazyTokenStream<'_> {
     type Item = Result<Tokens, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let t = self.string_iter.enumerate(); 
 
         match self.string_iter.next() {
             // numbers
@@ -84,7 +83,7 @@ impl Iterator for LazyTokenStream<'_> {
                     };
                 }
                 
-                Some(Ok(Tokens::Element { data: temp, meta: TokenMetadata::new(&temp, loc) }))
+                Some(Ok(Tokens::Element { data: temp.clone(), meta: TokenMetadata::new(&temp, loc) }))
             },
 
             Some((_, c)) => Some(Err(format!("Invalid Character: {}", c))),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,16 +1,16 @@
-use crate::token_types::{ParenType, Tokens};
-use std::{iter::{Iterator, Peekable}, str::Chars};
+use crate::token_types::{ParenType, Tokens, TokenMetadata};
+use std::{iter::{Iterator, Peekable, Enumerate}, str::Chars};
 
 /// An iterator that iterates over a string and parses it lazily
 pub struct LazyTokenStream<'a> {
-    string_iter: Peekable<Chars<'a>>,
+    string_iter: Peekable<Enumerate<Chars<'a>>>,
 }
 
 impl <'a> LazyTokenStream<'a> {
     /// Construct a new `LazyTokenStream` from the string
     pub fn new(string: &'a String) -> Self {
         Self {
-            string_iter: string.chars().peekable()
+            string_iter: string.chars().enumerate().peekable()
         }
     }
 }
@@ -30,38 +30,41 @@ impl Iterator for LazyTokenStream<'_> {
     type Item = Result<Tokens, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let t = self.string_iter.enumerate(); 
+
         match self.string_iter.next() {
             // numbers
-            Some(val @ '0'..='9') => {
+            Some((loc,val @ '0'..='9')) => {
                 let mut temp = String::new();
                 temp.push(val);
                 loop {
                     match self.string_iter.peek() {
-                        Some(inner_val @ '0'..='9') => {
+                        Some((_,inner_val @ '0'..='9')) => {
                             temp.push(*inner_val);
                             self.string_iter.next();
                         },
-                        Some(_) | None => { break Some(temp.parse::<u16>()
+                        Some(_) | None => {
+                            break Some(temp.parse::<u16>()
                             .map_err(|e| format!("Could not parse number: {e}"))
-                            .map(|value| Tokens::Number(value)));
+                            .map(|value| Tokens::Number { data: value, meta: TokenMetadata::new(&temp, loc) }));
                         }
                     }
                 }
             },
 
             // parens
-            Some('(') => Some(Ok(Tokens::Paren(ParenType::OPEN))),
-            Some(')') => Some(Ok(Tokens::Paren(ParenType::CLOSE))),
+            Some((loc, raw @ '(')) => Some(Ok(Tokens::Paren { data: ParenType::OPEN, meta: TokenMetadata::new(&raw.to_string(), loc) })),
+            Some((loc, raw @ ')')) => Some(Ok(Tokens::Paren { data: ParenType::CLOSE, meta: TokenMetadata::new(&raw.to_string(), loc) })),
 
             // plus
-            Some('+') => Some(Ok(Tokens::Plus)),
+            Some((loc, raw @ '+')) => Some(Ok(Tokens::Plus { meta: TokenMetadata::new(&raw.to_string(), loc) })),
 
             // yields
-            Some('-') => {
+            Some((loc, '-')) => {
                 match self.string_iter.peek() {
-                    Some('>') => {
+                    Some((_, '>')) => {
                         self.string_iter.next();
-                        Some(Ok(Tokens::Yields))
+                        Some(Ok(Tokens::Yields { meta: TokenMetadata::new("->", loc) }))
                     },
                     Some(_) => Some(Err("Yield sign (->) unfinished".to_owned())),
                     None => None
@@ -69,22 +72,22 @@ impl Iterator for LazyTokenStream<'_> {
             }
 
             // elements
-            Some(val @ 'A'..='Z') => {
+            Some((loc, val @ 'A'..='Z')) => {
                 let mut temp = String::new();
                 temp.push(val);
 
-                if let Some(inner_val @'a'..='z') = self.string_iter.peek() {
+                if let Some((_, inner_val @'a'..='z')) = self.string_iter.peek() {
                     temp.push(*inner_val);
                     self.string_iter.next();
-                    if let Some('a'..='z') = self.string_iter.peek() { // should not have 3 letter element names
+                    if let Some((_, 'a'..='z')) = self.string_iter.peek() { // should not have 3 letter element names
                         return Some(Err("Formula should not have 3 letter element names".to_owned()));
                     };
                 }
                 
-                Some(Ok(Tokens::Element(temp)))
+                Some(Ok(Tokens::Element { data: temp, meta: TokenMetadata::new(&temp, loc) }))
             },
 
-            Some(c) => Some(Err(format!("Invalid Character: {}", c))),
+            Some((_, c)) => Some(Err(format!("Invalid Character: {}", c))),
             None => None,
         }
     }
@@ -102,7 +105,7 @@ mod tests {
 
         assert!(res.is_ok(), "An error occurred while parsing");
 
-        let exp = vec!(Tokens::Element("Fe".to_owned()));
+        let exp = vec!(Tokens::Element { data: "Fe".to_owned(), meta: TokenMetadata::new("Fe",0)});
         
         assert_eq!(exp, res.unwrap());
     }
@@ -117,11 +120,11 @@ mod tests {
         assert!(res.is_ok(), "An error occurred while parsing");
 
         let exp = vec!(
-            Tokens::Number(2),
-            Tokens::Element("Fe".to_owned()),
-            Tokens::Element("C".to_owned()),
-            Tokens::Element("O".to_owned()),
-            Tokens::Number(3),
+            Tokens::Number{ data: 2, meta: TokenMetadata::new("2", 0) },
+            Tokens::Element{ data: "Fe".to_owned(), meta: TokenMetadata::new("Fe", 1)},
+            Tokens::Element{ data: "C".to_owned(), meta: TokenMetadata::new("C", 3)},
+            Tokens::Element{ data: "O".to_owned(), meta: TokenMetadata::new("O", 4)},
+            Tokens::Number{ data: 3, meta: TokenMetadata::new("3", 5)},
         );
         
         assert_eq!(exp, res.unwrap());
@@ -136,22 +139,22 @@ mod tests {
 
         assert!(res.is_ok(), "An error occurred while parsing: {}", res.err().unwrap() );
 
-        let exp = vec!(
-            Tokens::Number(2),
-            Tokens::Element("Fe".to_owned()),
-            Tokens::Plus,
-            Tokens::Element("Na".to_owned()),
-            Tokens::Number(2),
-            Tokens::Element("F".to_owned()),
-            Tokens::Number(3),
-            Tokens::Yields,
-            Tokens::Number(2),
-            Tokens::Element("Fe".to_owned()),
-            Tokens::Element("Na".to_owned()),
-            Tokens::Plus,
-            Tokens::Element("F".to_owned()),
-            Tokens::Number(3),
-        );
+        let exp = vec![
+            Tokens::Number{ data: 2, meta: TokenMetadata::new("2", 0)},
+            Tokens::Element{ data: "Fe".to_owned(), meta: TokenMetadata::new("Fe", 1)},
+            Tokens::Plus{ meta: TokenMetadata::new("+", 3) },
+            Tokens::Element{ data: "Na".to_owned(), meta: TokenMetadata::new("Na", 4)},
+            Tokens::Number{ data: 2, meta: TokenMetadata::new("2", 6)},
+            Tokens::Element{ data: "F".to_owned(), meta: TokenMetadata::new("F", 7)},
+            Tokens::Number{ data: 3, meta: TokenMetadata::new("3", 8) },
+            Tokens::Yields{ meta: TokenMetadata::new("->", 9)},
+            Tokens::Number{ data: 2, meta: TokenMetadata::new("2", 11)},
+            Tokens::Element{ data: "Fe".to_owned(), meta: TokenMetadata::new("Fe", 12)},
+            Tokens::Element{ data: "Na".to_owned(), meta: TokenMetadata::new("Na", 14)},
+            Tokens::Plus{ meta: TokenMetadata::new("+", 16) },
+            Tokens::Element{ data: "F".to_owned(), meta: TokenMetadata::new("F", 17)},
+            Tokens::Number{ data: 3, meta: TokenMetadata::new("3", 17)},
+        ];
         
         assert_eq!(exp, res.unwrap());
     }

--- a/src/token_types.rs
+++ b/src/token_types.rs
@@ -9,16 +9,46 @@ pub enum ParenType {
 }
 
 /// A token which may have attached data
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Tokens {
     /// Elements e.g. Fe. The data is "Fe"
-    Element(String),
+    Element { data: String, meta: TokenMetadata },
     /// Numbers e.g. 13. The data is 13u16
-    Number(u16),
+    Number { data: u16, meta: TokenMetadata },
     /// Parenthesis e.g. ) The data is ParenType::CLOSE
-    Paren(ParenType),
+    Paren { data: ParenType, meta: TokenMetadata },
     /// Plus sign +
-    Plus,
+    Plus { meta: TokenMetadata},
     /// Yields sign -> 
-    Yields,
+    Yields { meta: TokenMetadata },
+}
+
+impl Tokens {
+    pub fn meta(&self) -> TokenMetadata {
+        match *self {
+            Self::Element { meta, data: _ } => meta,
+            Self::Number { meta, data: _ } => meta,
+            Self::Paren { meta, data: _ } => meta,
+            Self::Plus { meta} => meta,
+            Self::Yields { meta} => meta
+        }
+    }
+}
+
+impl PartialEq for Tokens {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Element { data: l_data, meta: _ }, Self::Element { data: r_data, meta: r_meta }) => l_data == r_data,
+            (Self::Number { data: l_data, meta: _ }, Self::Number { data: r_data, meta: r_meta }) => l_data == r_data,
+            (Self::Paren { data: l_data, meta: _ }, Self::Paren { data: r_data, meta: r_meta }) => l_data == r_data,
+            (Self::Plus { meta: l_meta }, Self::Plus { meta: _ }) => true,
+            (Self::Yields { meta: l_meta }, Self::Yields { meta: _ }) => true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TokenMetadata {
+    raw: String,
+    location: usize
 }

--- a/src/token_types.rs
+++ b/src/token_types.rs
@@ -52,3 +52,13 @@ pub struct TokenMetadata {
     raw: String,
     location: usize
 }
+
+
+impl TokenMetadata {
+    pub fn new(raw: &str, location: usize) -> Self {
+        Self {
+            raw: raw.into(),
+            location
+        }
+    }
+}

--- a/src/token_types.rs
+++ b/src/token_types.rs
@@ -24,8 +24,8 @@ pub enum Tokens {
 }
 
 impl Tokens {
-    pub fn meta(&self) -> TokenMetadata {
-        match *self {
+    pub fn meta(&self) -> &TokenMetadata {
+        match self {
             Self::Element { meta, data: _ } => meta,
             Self::Number { meta, data: _ } => meta,
             Self::Paren { meta, data: _ } => meta,
@@ -38,11 +38,12 @@ impl Tokens {
 impl PartialEq for Tokens {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Element { data: l_data, meta: _ }, Self::Element { data: r_data, meta: r_meta }) => l_data == r_data,
-            (Self::Number { data: l_data, meta: _ }, Self::Number { data: r_data, meta: r_meta }) => l_data == r_data,
-            (Self::Paren { data: l_data, meta: _ }, Self::Paren { data: r_data, meta: r_meta }) => l_data == r_data,
-            (Self::Plus { meta: l_meta }, Self::Plus { meta: _ }) => true,
-            (Self::Yields { meta: l_meta }, Self::Yields { meta: _ }) => true,
+            (Self::Element { data: l_data, meta: _ }, Self::Element { data: r_data, meta: _ }) => l_data == r_data,
+            (Self::Number { data: l_data, meta: _ }, Self::Number { data: r_data, meta: _ }) => l_data == r_data,
+            (Self::Paren { data: l_data, meta: _ }, Self::Paren { data: r_data, meta: _ }) => l_data == r_data,
+            (Self::Plus { meta: _ }, Self::Plus { meta: _ }) => true,
+            (Self::Yields { meta: _ }, Self::Yields { meta: _ }) => true,
+            _ => false
         }
     }
 }
@@ -60,5 +61,11 @@ impl TokenMetadata {
             raw: raw.into(),
             location
         }
+    }
+    pub fn raw(&self) -> &String {
+        &self.raw
+    }
+    pub fn loc(&self) -> usize {
+        self.location
     }
 }


### PR DESCRIPTION
The current lexer does not store metadata about the token, such as the raw string for it, or its location. With the new metadata, this will enable future updates to have enhanced error messages.